### PR TITLE
Adds code for redacting Obsidian comments

### DIFF
--- a/src/lava-flow-settings.ts
+++ b/src/lava-flow-settings.ts
@@ -18,4 +18,5 @@ export class LavaFlowSettings {
   combineNotes = false;
   combineNotesNoSubfolders = true;
   useTinyMCE = false;
+  stripObsidianComments: boolean = true; // or false if you prefer opt-in
 }

--- a/templates/lava-flow-import.hbs
+++ b/templates/lava-flow-import.hbs
@@ -60,7 +60,17 @@
     <div class="form-group" title="The TinyMCE editor will be used to edit pages instead of Markdown.">
         <label>Use TinyMCE to edit pages? <i class="far fa-question-circle"></i></label>
         <input type="checkbox" name="useTinyMCE" id="{{idPrefix}}useTinyMCE" {{#if useTinyMCE}}checked{{/if}}>
-    </div>   
+    </div>
+
+    <div class="form-group">
+        <label for="{{idPrefix}}stripObsidianComments">Strip Obsidian comments (%%...%%)</label>
+        <input type="checkbox"
+                id="{{idPrefix}}stripObsidianComments"
+                name="stripObsidianComments"
+                {{#if stripObsidianComments}}checked{{/if}}>
+        <p class="notes">If enabled, content inside %%…%% will be removed before import.</p>
+    </div>
+   
 
     <h1>Non-Markdown Options</h1>
     <div class="form-group" title="Non-markdown files, like images, will be loaded to the game server or S3.">


### PR DESCRIPTION
Adds an option for users to redact comments from their Obsidian notes upon import. I use this to keep relevant DM notes, links, etc. in the appropriate Obsidian files but hide the content from users in the Foundry journals.